### PR TITLE
Make sam.nim work at compiletime

### DIFF
--- a/jsmn.nim
+++ b/jsmn.nim
@@ -59,8 +59,7 @@ type
     start*: int ## start position in JSON data string
     stop*: int ## end position in JSON data string
     size*: int
-    when not defined(JSMN_NO_PARENT_LINKS):
-      parent*: int
+    parent*: int
 
   JsmnParser = object
     pos: int


### PR DESCRIPTION
This module rocks because of it's ability to run at compile-time, sadly a small fix is needed to make it with with Sam.nim.

Basically the nim VM does not seem to care about `when defined` in types ( at least in the current version ), this small adjustment should have no consequences since changes only the type.

Removing this line is probably faster then fixing it nim compiler side ( which would be better tho ).